### PR TITLE
[TASK] Add symfony/event-dispatcher-contracts v1 compatible adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "typo3/symfony-psr-event-dispatcher-adapter",
+    "description": "Adapter to provide compatibility with the Symfony's event dispatcher interface in all versions with the PSR-14 specification.",
+    "type": "library",
+    "license": "MIT",
+    "homepage": "https://typo3.org/",
+    "keywords": ["psr", "psr-14", "events", "adapter"],
+    "require": {
+        "php": "^7.2",
+        "symfony/event-dispatcher-contracts": "^1.0",
+        "psr/event-dispatcher": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "TYPO3\\SymfonyPsrEventDispatcherAdapter\\": "src"
+        }
+    }
+}

--- a/src/SymfonyEventDispatcherAdapter.php
+++ b/src/SymfonyEventDispatcherAdapter.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\SymfonyPsrEventDispatcherAdapter;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherInterface;
+
+final class SymfonyEventDispatcherAdapter implements SymfonyEventDispatcherInterface
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function dispatch($event)
+    {
+        return $this->eventDispatcher->dispatch($event);
+    }
+}


### PR DESCRIPTION
This event dispatcher is comaptible with Symfony v4.

It should be tagged as 1.0.0 once merged.