### PR TITLE
[TASK] Make adapter compatible to symfony/event-dispatcher-contracts v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "keywords": ["psr", "psr-14", "events", "adapter"],
     "require": {
         "php": "^7.2",
-        "symfony/event-dispatcher-contracts": "^1.0",
+        "symfony/event-dispatcher-contracts": "^2.0",
         "psr/event-dispatcher": "^1.0"
     },
     "autoload": {

--- a/src/EventDispatcherAdapter.php
+++ b/src/EventDispatcherAdapter.php
@@ -35,7 +35,7 @@ final class EventDispatcherAdapter implements SymfonyEventDispatcherInterface
     /**
      * @inheritdoc
      */
-    public function dispatch($event)
+    public function dispatch(object $event, string $eventName = null): object
     {
         return $this->eventDispatcher->dispatch($event);
     }


### PR DESCRIPTION
This requires a major version bump (to **2.0.0**), as we switch from
event-dispatcher-contracts v1 to v2, which
implicitly means support for symfony v5 instead of v4.


Note: This depends on #1 and #3 and should be merged afterwards.