### PR TITLE
[TASK] Switch adapter class name to EventDispatcherAdapter

### DIFF
--- a/src/EventDispatcherAdapter.php
+++ b/src/EventDispatcherAdapter.php
@@ -20,7 +20,7 @@ namespace TYPO3\SymfonyPsrEventDispatcherAdapter;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherInterface;
 
-final class SymfonyEventDispatcherAdapter implements SymfonyEventDispatcherInterface
+final class EventDispatcherAdapter implements SymfonyEventDispatcherInterface
 {
     /**
      * @var EventDispatcherInterface


### PR DESCRIPTION
SymfonyEventDispatcherAdapter is incomplete, as
"Psr" is missing then, therefore it's better to
just use EventDispatcherAdapter.